### PR TITLE
Sony A6600 does not support new iso, so make it false

### DIFF
--- a/camera/ptpjs/drivers/sony.js
+++ b/camera/ptpjs/drivers/sony.js
@@ -64,7 +64,7 @@ driver.supportedCameras = {
     '054c:0c34': { name: "Sony A7 III",   supports: { shutter: true, aperture: true, iso: true, liveview: true,  destination: true,  focus: true,  _bufTime: 2500, newISO: false } },
     '054c:0caa': { name: "Sony A6400",    supports: { shutter: true, aperture: true, iso: true, liveview: true,  destination: true,  focus: true,  _bufTime: 3000, newISO: false } },
     '054c:0ccc': { name: "Sony A7R IV",   supports: { shutter: true, aperture: true, iso: true, liveview: true,  destination: true,  focus: true,  _bufTime: 2500, newISO: true  } },
-    '054c:0d10': { name: "Sony A6600",    supports: { shutter: true, aperture: true, iso: true, liveview: true,  destination: true,  focus: true,  _bufTime: 3000, newISO: true  } },
+    '054c:0d10': { name: "Sony A6600",    supports: { shutter: true, aperture: true, iso: true, liveview: true,  destination: true,  focus: true,  _bufTime: 3000, newISO: false  } },
     '054c:0d18': { name: "Sony A7S III",  supports: { shutter: true, aperture: true, iso: true, liveview: true,  destination: true,  focus: true,  _bufTime: 2500, newISO: true  } },
     '054c:0d2b': { name: "Sony A7C",      supports: { shutter: true, aperture: true, iso: true, liveview: true,  destination: true,  focus: true,  _bufTime: 2500, newISO: true  } },
     '054c:0d9f': { name: "Sony A7R IV A", supports: { shutter: true, aperture: true, iso: true, liveview: true,  destination: true,  focus: true,  _bufTime: 2500, newISO: true  } },


### PR DESCRIPTION
As I have mentioned before, mine A6600 doesn't acquire iso settings in a new driver, because it supposed to work with `newISO` but it doesn't